### PR TITLE
fix: バージョンをsemver形式からHaskell PVP形式に変更

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yesod-recaptcha2
-version: 1.0.2
+version: 1.0.2.0
 synopsis: yesod recaptcha2
 description: It support new Google reCAPTCHA(v2, v3) for yesod-form instead yesod-recaptcha beacuse original yesod-recaptcha is dead.
 github: ncaq/yesod-recaptcha2

--- a/yesod-recaptcha2.cabal
+++ b/yesod-recaptcha2.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           yesod-recaptcha2
-version:        1.0.2
+version:        1.0.2.0
 synopsis:       yesod recaptcha2
 description:    It support new Google reCAPTCHA(v2, v3) for yesod-form instead yesod-recaptcha beacuse original yesod-recaptcha is dead.
 category:       Web


### PR DESCRIPTION
semver形式でも致命傷にはならないみたいですが、
Haskell PVP形式の方が他のツールとの噛み合わせが良いらしいので変更します。
変換ルールを考えると`0.3.0.1`の方が適切な気もしますが、
バージョンを遡ってしまうので妥協します。